### PR TITLE
Fixed DB names not matching in the containers

### DIFF
--- a/docker-compose/nginxproxymanager/docker-compose.yaml
+++ b/docker-compose/nginxproxymanager/docker-compose.yaml
@@ -13,7 +13,7 @@ services:
       - '81:81'
       - '443:443'
     environment:
-      DB_MYSQL_HOST: "db"
+      DB_MYSQL_HOST: "nginxproxymanager-db"
       DB_MYSQL_PORT: 3306
       DB_MYSQL_USER: "npm"
       DB_MYSQL_PASSWORD: "npm"


### PR DESCRIPTION
Changed MySQL hostname in the nignxproxymanager image from "db"(default setting from the official example) to match the name of the MariaDB container