### PR TITLE
Use ansible_env fact instead of lookup plugin as the latter queries controller instead of remote

### DIFF
--- a/ansible/provisoning/ubuntu/install-docker.yaml
+++ b/ansible/provisoning/ubuntu/install-docker.yaml
@@ -34,7 +34,7 @@
       update_cache: yes
 
   - name: add user permissions
-    shell: "usermod -aG docker {{ ansible_env.USER }}"
+    shell: "usermod -aG docker {{ ansible_env.SUDO_USER }}"
 
   # Installs Docker SDK
   # --
@@ -44,7 +44,7 @@
       name: python3-pip
   
   - name: install python sdk
-    become_user: "{{ ansible_env.USER }}"
+    become_user: "{{ ansible_env.SUDO_USER }}"
     pip:
       name:
         - docker

--- a/ansible/provisoning/ubuntu/install-docker.yaml
+++ b/ansible/provisoning/ubuntu/install-docker.yaml
@@ -33,8 +33,8 @@
         - containerd.io
       update_cache: yes
 
-  - name: add userpermissions
-    shell: "usermod -aG docker {{ lookup('env','USER') }}"
+  - name: add user permissions
+    shell: "usermod -aG docker {{ ansible_env.USER }}"
 
   # Installs Docker SDK
   # --
@@ -44,7 +44,7 @@
       name: python3-pip
   
   - name: install python sdk
-    become_user: "{{ lookup('env','USER') }}"
+    become_user: "{{ ansible_env.USER }}"
     pip:
       name:
         - docker

--- a/ansible/provisoning/ubuntu/install-docker.yaml
+++ b/ansible/provisoning/ubuntu/install-docker.yaml
@@ -36,6 +36,9 @@
   - name: add user permissions
     shell: "usermod -aG docker {{ ansible_env.SUDO_USER }}"
 
+  - name: Reset ssh connection for changes to take effect
+    meta: "reset_connection"
+
   # Installs Docker SDK
   # --
   # 


### PR DESCRIPTION
From [lookup plugin documentation](https://docs.ansible.com/ansible/latest/collections/ansible/builtin/env_lookup.html#synopsis)

> Allows you to query the environment variables available on the controller when you invoked Ansible.

I assume the intended user here is the one in the VM (`vagrant` from your video) which can be accessed through `ansible_env` fact.

**EDIT:**
Added a `reset_connection` step after adding user to docker group, as per [docker post installation steps](https://docs.docker.com/engine/install/linux-postinstall/#:~:text=If%20testing%20on%20a%20virtual%20machine%2C%20it%20may%20be%20necessary%20to%20restart%20the%20virtual%20machine%20for%20changes%20to%20take%20effect.) this will allow change to take effect and prevent permission errors from hapenning later.

P.S. thanks for the great content.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will help the moderators review your PR. -->

- [x] My pull request has a descriptive title. (unlike `Update index.md`). Check [this](https://www.conventionalcommits.org/en/v1.0.0/) guide regarding titles.
- [x] If applicable, I have tested these changes.

