### PR TITLE
Update cadvisor to `latest` version - not using the latest tag

### DIFF
--- a/docker-compose/prometheus/exporters/cadvisor/docker-compose.yml
+++ b/docker-compose/prometheus/exporters/cadvisor/docker-compose.yml
@@ -3,7 +3,9 @@ version: '3'
 
 services:
   cadvisor:
-    image: gcr.io/cadvisor/cadvisor:latest
+    image: gcr.io/cadvisor/cadvisor:v0.45.0 # latest tag is not updated...
+                                            # https://github.com/google/cadvisor/issues/3066    
+                                            # To manual check versions: https://github.com/google/cadvisor/releases      
     container_name: cadvisor
     # ports:
     #   - "8080:8080"


### PR DESCRIPTION
**Checklist:**
- [x] My pull request has a descriptive title. (unlike `Update index.md`). Check [this](https://www.conventionalcommits.org/en/v1.0.0/) guide regarding titles.
- [x] If applicable, I have tested these changes.

**Description:**

Since they don't update the latest tag... the latest tag is now 20 months old and it seems like they will/can not update it in the future...
Unsure what to do about that but for now I would just update the tag... ^^'
