### PR TITLE
Cadvisor needs host networking

### DIFF
--- a/docker-compose/prometheus/exporters/cadvisor/docker-compose.yml
+++ b/docker-compose/prometheus/exporters/cadvisor/docker-compose.yml
@@ -9,6 +9,7 @@ services:
     container_name: cadvisor
     # ports:
     #   - "8080:8080"
+    network_mode: host
     volumes:
       - /:/rootfs:ro
       - /var/run:/var/run:ro


### PR DESCRIPTION
Hi,

Cadvisor needs host networking or it can only see the network interfaces in the Cadvisor container itself, not all the interfaces of the docker server
